### PR TITLE
ak-branch-1

### DIFF
--- a/expert/addons/amit-fit/components/AutoFit.vue
+++ b/expert/addons/amit-fit/components/AutoFit.vue
@@ -66,7 +66,8 @@ watchEffect(schedule)
 :slotted(ul), :slotted(ol) {
   max-width: 90vw;
   word-break: break-word;
-  margin: 0;            /* NEW: remove default margins */
-  padding-left: 1.25rem;/* keep bullets indented nicely */
+  margin: 0;              /* important: no extra top/bottom margin */
+  padding-left: 1.25rem;  /* nice bullet indent */
 }
 </style>
+

--- a/expert/addons/amit-fit/layouts/bullets-fit.vue
+++ b/expert/addons/amit-fit/layouts/bullets-fit.vue
@@ -3,17 +3,33 @@ import AutoFit from '../components/AutoFit.vue'
 </script>
 
 <template>
-  <!-- 2-row grid: header (auto height) + content (fills the rest) -->
+  <!-- Two rows: title area (fixed height) + content area (fills the rest) -->
   <div class="slidev-layout default h-full grid" style="grid-template-rows: auto 1fr;">
-    <!-- Header: uses front-matter title if provided -->
-    <div class="pb-4">
-      <h1 v-if="$frontmatter.title" class="m-0">{{$frontmatter.title}}</h1>
-      <slot name="header" />
+    <!-- ===== TITLE ROW ===== -->
+    <div
+      v-if="$frontmatter.title"
+      class="min-h-0"
+      :style="{
+        /* Use per-slide override if provided; else CSS var; else 10vh */
+        height: ($frontmatter.titleHeight ?? 'var(--amit-title-height, 10vh)')
+      }"
+    >
+      <AutoFit
+        :min="$frontmatter.titleMin ?? 28"
+        :max="$frontmatter.titleMax ?? 64"
+        :pad="$frontmatter.titlePad ?? 8"
+      >
+        <!-- Neutralize theme font-size so AutoFit governs -->
+        <h1 class="m-0 font-extrabold leading-[1.06] tracking-[-0.02em] auto-title"
+            style="text-wrap: balance; hyphens: auto;">
+          {{ $frontmatter.title }}
+        </h1>
+      </AutoFit>
     </div>
 
-    <!-- Content area: min-h-0 so it can actually shrink; AutoFit sizes bullets to fill -->
+    <!-- ===== CONTENT ROW (BULLETS) ===== -->
     <div class="min-h-0">
-      <AutoFit :min="20" :max="60" :pad="12">
+      <AutoFit :min="20" :max="52" :pad="12">
         <slot />
       </AutoFit>
     </div>
@@ -23,7 +39,10 @@ import AutoFit from '../components/AutoFit.vue'
 </template>
 
 <style scoped>
-/* If someone writes a Markdown H1/H2 in the content, hide the first one so it doesn't double with front-matter title */
+/* If someone types an H1/H2 in the body, hide the first so we don't double-render titles */
 .prose :is(h1,h2):first-child { display: none; }
+
+/* Critical: let AutoFit control the title size */
+.auto-title { font-size: 1em; }
 </style>
 

--- a/expert/addons/amit-fit/styles.css
+++ b/expert/addons/amit-fit/styles.css
@@ -1,4 +1,33 @@
-.slidev-layout h1 { font-size: clamp(2.8rem, 6.5vmin, 5.2rem); line-height: 1.08; font-weight: 800; letter-spacing: -0.02em; }
-.slidev-layout h2 { font-size: clamp(2.2rem, 5vmin, 3.6rem); line-height: 1.12; font-weight: 800; }
-.slidev-layout h3 { font-size: clamp(1.6rem, 3.6vmin, 2.4rem); line-height: 1.18; font-weight: 700; }
+/* ===== Global knobs (one place to tune defaults) ===== */
+:root {
+  /* Optional suggestion: change this to adjust the default title area once for the whole deck */
+  --amit-title-height: 10vh;
+}
+
+/* Headings: “Keynote big” but still classy.
+   Note: the layout’s <h1> uses .auto-title { font-size: 1em } to neutralize these sizes
+   so AutoFit can govern the displayed size. */
+.slidev-layout h1{
+  font-size: clamp(2.8rem, 6.5vmin, 5.2rem);
+  line-height: 1.08;
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+.slidev-layout h2{
+  font-size: clamp(2.2rem, 5vmin, 3.6rem);
+  line-height: 1.12;
+  font-weight: 800;
+}
+.slidev-layout h3{
+  font-size: clamp(1.6rem, 3.6vmin, 2.4rem);
+  line-height: 1.18;
+  font-weight: 700;
+}
+
+/* Utility: vertical center */
+.center-v {
+  display: grid;
+  height: 100%;
+  place-content: center;
+}
 

--- a/expert/expert-slides/Python in Depth Course plan.md
+++ b/expert/expert-slides/Python in Depth Course plan.md
@@ -55,6 +55,12 @@ title: Day 3 — OOP Mastery
 layout: bullets-fit
 title: Day 4 — Metaprogramming & Practice
 ---
+<!-- Optional per-slide overrides: -->
+<!-- # titleHeight: 10vh -->
+<!-- # titleHeight: 12vh -->
+<!-- # titleMin: 28 -->
+<!-- # titleMax: 60 -->
+<!-- # titlePad: 8 -->
 
 - Metaclasses
 - getattr / getattribute


### PR DESCRIPTION
- Improved title and bullet sizing in the `bullets-fit` layout
- Added optional per-slide overrides for the Day 4 slides in the "Python in Depth Course plan" document to customize title height, minimum and maximum title size, and title padding