### PR TITLE
ak-branch-2

### DIFF
--- a/expert/addons/amit-fit/components/AutoFit.vue
+++ b/expert/addons/amit-fit/components/AutoFit.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { onMounted, onBeforeUnmount, ref, watchEffect, nextTick } from 'vue'
+import { onMounted, onBeforeUnmount, ref, nextTick } from 'vue'
 
 interface Props {
   min?: number
@@ -7,17 +7,29 @@ interface Props {
   step?: number
   pad?: number
 }
-const props = withDefaults(defineProps<Props>(), { min: 18, max: 56, step: 1, pad: 0 })
+const props = withDefaults(defineProps<Props>(), {
+  min: 18,
+  max: 56,
+  step: 1,
+  pad: 0,
+})
 
-const box = ref<HTMLDivElement|null>(null)
-const inner = ref<HTMLDivElement|null>(null)
+const box = ref<HTMLDivElement | null>(null)
+const inner = ref<HTMLDivElement | null>(null)
+
 let ro: ResizeObserver | null = null
-let raf = 0
+let rafId = 0
+let debounceId: number | undefined
 
-function fits(px: number) {
-  const b = box.value!, i = inner.value!
-  i.style.fontSize = `${px}px`
-  // force layout
+// Hysteresis: remember last measured size; ignore sub-pixel changes
+let lastW = -1
+let lastH = -1
+
+function fits(fontPx: number): boolean {
+  const b = box.value!
+  const i = inner.value!
+  i.style.fontSize = `${fontPx}px`
+  // Force layout before measuring
   // eslint-disable-next-line @typescript-eslint/no-unused-expressions
   i.offsetHeight
   const wOk = i.scrollWidth <= (b.clientWidth - props.pad * 2)
@@ -25,49 +37,81 @@ function fits(px: number) {
   return wOk && hOk
 }
 
-function fit() {
+function fitNow() {
   if (!box.value || !inner.value) return
-  let lo = props.min, hi = props.max, best = lo
+  const w = box.value.clientWidth
+  const h = box.value.clientHeight
+  if (w === 0 || h === 0) {
+    // Safe fallback so content is visible even if initial measurement is 0×0
+    inner.value.style.fontSize = `${props.min}px`
+    // Try again on the next tick
+    requestAnimationFrame(() => nextTick().then(fitNow))
+    return
+  }
+  let lo = props.min
+  let hi = props.max
+  let best = lo
   while (lo <= hi) {
     const mid = Math.floor((lo + hi) / 2)
-    if (fits(mid)) { best = mid; lo = mid + props.step }
-    else { hi = mid - props.step }
+    if (fits(mid)) { best = mid; lo = mid + (props.step ?? 1) }
+    else { hi = mid - (props.step ?? 1) }
   }
   inner.value!.style.fontSize = `${best}px`
 }
 
 function schedule() {
-  cancelAnimationFrame(raf)
-  raf = requestAnimationFrame(() => { nextTick().then(fit) })
+  cancelAnimationFrame(rafId)
+  rafId = requestAnimationFrame(() => {
+    if (!box.value) return
+    const w = box.value.clientWidth
+    const h = box.value.clientHeight
+    // Only re-fit if a meaningful size change happened (>= 1 CSS px)
+    if (Math.abs(w - lastW) < 1 && Math.abs(h - lastH) < 1) return
+    lastW = w; lastH = h
+    // Coalesce bursts of RO/resize events
+    if (debounceId) clearTimeout(debounceId)
+    debounceId = window.setTimeout(() => { nextTick().then(fitNow) }, 50)
+  })
 }
 
 onMounted(() => {
   schedule()
-  ro = new ResizeObserver(schedule)
+  ro = new ResizeObserver(() => schedule())
   if (box.value) ro.observe(box.value)
   if (inner.value) ro.observe(inner.value)
   window.addEventListener('resize', schedule, { passive: true })
+  window.addEventListener('orientationchange', schedule, { passive: true })
+  // Re-fit when webfonts finish loading (prevents post-load shrink)
+  // @ts-expect-error: fonts is not in lib.dom.d.ts in some TS targets
+  if (document.fonts?.ready) document.fonts.ready.then(() => schedule())
 })
+
 onBeforeUnmount(() => {
-  cancelAnimationFrame(raf)
+  cancelAnimationFrame(rafId)
+  if (debounceId) clearTimeout(debounceId)
   ro?.disconnect()
   window.removeEventListener('resize', schedule)
+  window.removeEventListener('orientationchange', schedule)
 })
-watchEffect(schedule)
 </script>
 
 <template>
-  <div ref="box" class="grid h-full place-content-center">
-    <div ref="inner" style="line-height:1.18"><slot /></div>
+  <!-- IMPORTANT: min-h-0 to allow shrinking inside any flex/grid parent -->
+  <div ref="box" class="grid h-full min-h-0 place-content-center">
+    <div ref="inner" style="line-height:1.18">
+      <slot />
+    </div>
   </div>
 </template>
 
 <style scoped>
+/* Keep lists compact and measurement-stable inside AutoFit */
+::v-slotted(ul), ::v-slotted(ol),
 :slotted(ul), :slotted(ol) {
   max-width: 90vw;
   word-break: break-word;
-  margin: 0;              /* important: no extra top/bottom margin */
-  padding-left: 1.25rem;  /* nice bullet indent */
+  margin: 0;
+  padding-left: var(--amit-bullet-indent, 1.25rem);
 }
 </style>
 

--- a/expert/addons/amit-fit/layouts/bullets-fit.vue
+++ b/expert/addons/amit-fit/layouts/bullets-fit.vue
@@ -3,35 +3,55 @@ import AutoFit from '../components/AutoFit.vue'
 </script>
 
 <template>
-  <!-- Two rows: title area (fixed height) + content area (fills the rest) -->
-  <div class="slidev-layout default h-full grid" style="grid-template-rows: auto 1fr;">
+  <!-- FLEX instead of grid: fewer edge-cases with collapsed rows -->
+  <div class="slidev-layout default h-full min-h-0 flex flex-col">
     <!-- ===== TITLE ROW ===== -->
     <div
       v-if="$frontmatter.title"
-      class="min-h-0"
-      :style="{
-        /* Use per-slide override if provided; else CSS var; else 10vh */
-        height: ($frontmatter.titleHeight ?? 'var(--amit-title-height, 10vh)')
-      }"
+      class="shrink-0 min-h-0"
+      :style="{ height: ($frontmatter.titleHeight ?? 'var(--amit-title-height, 10vh)') }"
     >
-      <AutoFit
-        :min="$frontmatter.titleMin ?? 28"
-        :max="$frontmatter.titleMax ?? 64"
-        :pad="$frontmatter.titlePad ?? 8"
-      >
-        <!-- Neutralize theme font-size so AutoFit governs -->
-        <h1 class="m-0 font-extrabold leading-[1.06] tracking-[-0.02em] auto-title"
-            style="text-wrap: balance; hyphens: auto;">
-          {{ $frontmatter.title }}
-        </h1>
-      </AutoFit>
+      <div class="h-full min-h-0">
+        <AutoFit
+          :min="$frontmatter.titleMin ?? 28"
+          :max="$frontmatter.titleMax ?? 56"
+          :pad="$frontmatter.titlePad ?? 8"
+        >
+          <!-- Neutralize theme size so AutoFit governs -->
+          <h1 class="m-0 font-extrabold leading-[1.06] tracking-[-0.02em] auto-title"
+              style="text-wrap: balance; hyphens: auto;">
+            {{ $frontmatter.title }}
+          </h1>
+        </AutoFit>
+      </div>
     </div>
 
-    <!-- ===== CONTENT ROW (BULLETS) ===== -->
-    <div class="min-h-0">
-      <AutoFit :min="20" :max="52" :pad="12">
-        <slot />
-      </AutoFit>
+    <!-- ===== OPTIONAL SUBTITLE ROW ===== -->
+    <div
+      v-if="$frontmatter.subtitle"
+      class="shrink-0 min-h-0"
+      :style="{ height: ($frontmatter.subtitleHeight ?? 'var(--amit-subtitle-height, 6vh)') }"
+    >
+      <div class="h-full min-h-0">
+        <AutoFit
+          :min="$frontmatter.subtitleMin ?? 18"
+          :max="$frontmatter.subtitleMax ?? 32"
+          :pad="$frontmatter.subtitlePad ?? 6"
+        >
+          <h2 class="m-0 font-semibold auto-subtitle" style="text-wrap: balance; hyphens: auto;">
+            {{ $frontmatter.subtitle }}
+          </h2>
+        </AutoFit>
+      </div>
+    </div>
+
+    <!-- ===== CONTENT (BULLETS) ===== -->
+    <div class="flex-1 min-h-0">
+      <div class="content-box h-full min-h-0">
+        <AutoFit :min="22" :max="52" :pad="12">
+          <slot />
+        </AutoFit>
+      </div>
     </div>
 
     <slot name="footer" />
@@ -42,7 +62,17 @@ import AutoFit from '../components/AutoFit.vue'
 /* If someone types an H1/H2 in the body, hide the first so we don't double-render titles */
 .prose :is(h1,h2):first-child { display: none; }
 
-/* Critical: let AutoFit control the title size */
+/* Critical: let AutoFit control the title/subtitle size */
 .auto-title { font-size: 1em; }
+.auto-subtitle { font-size: 1em; }
+
+/* Safe areas + max readable width for bullets */
+.content-box {
+  padding-left: var(--amit-safe-x, 6vw);
+  padding-right: var(--amit-safe-x, 6vw);
+  max-width: var(--amit-max-content, 80ch);
+  margin-left: auto;
+  margin-right: auto;
+}
 </style>
 

--- a/expert/addons/amit-fit/layouts/cover-fit.vue
+++ b/expert/addons/amit-fit/layouts/cover-fit.vue
@@ -1,0 +1,69 @@
+<script setup lang="ts">
+import AutoFit from '../components/AutoFit.vue'
+</script>
+
+<template>
+  <!-- Center the whole stack; keep heights flexible and safe -->
+  <div class="slidev-layout default h-full min-h-0 flex items-center justify-center relative">
+    <div class="w-full px-[var(--amit-safe-x,6vw)] max-w-[min(120ch,90vw)]">
+
+      <!-- Title -->
+      <div class="min-h-0" :style="{ height: ($frontmatter.coverTitleHeight ?? 'var(--cover-title-height, 32vh)') }">
+        <AutoFit
+          :min="$frontmatter.titleMin ?? 32"
+          :max="$frontmatter.titleMax ?? 96"
+          :pad="$frontmatter.titlePad ?? 8"
+        >
+          <h1 class="m-0 font-extrabold auto-title"
+              style="text-wrap: balance; hyphens: auto; letter-spacing:-0.02em; line-height:1.04;">
+            {{ $frontmatter.title || $frontmatter.coverTitle || '' }}
+          </h1>
+        </AutoFit>
+      </div>
+
+      <!-- Subtitle (optional) -->
+      <div v-if="$frontmatter.subtitle" class="min-h-0 mt-2"
+           :style="{ height: ($frontmatter.coverSubtitleHeight ?? 'var(--cover-subtitle-height, 14vh)') }">
+        <AutoFit
+          :min="$frontmatter.subtitleMin ?? 22"
+          :max="$frontmatter.subtitleMax ?? 40"
+          :pad="$frontmatter.subtitlePad ?? 6"
+        >
+          <h2 class="m-0 font-semibold auto-subtitle"
+              style="text-wrap: balance; hyphens: auto; line-height:1.06;">
+            {{ $frontmatter.subtitle }}
+          </h2>
+        </AutoFit>
+      </div>
+
+      <!-- Presenter / meta (name, email, org/website—each optional) -->
+      <div class="min-h-0 mt-6" :style="{ height: ($frontmatter.coverMetaHeight ?? 'var(--cover-meta-height, 12vh)') }">
+        <AutoFit :min="$frontmatter.metaMin ?? 16" :max="$frontmatter.metaMax ?? 22" :pad="4">
+          <div class="text-center leading-tight">
+            <div v-if="$frontmatter.by" class="font-semibold">{{ $frontmatter.by }}</div>
+            <div v-if="$frontmatter.email">
+              <a :href="`mailto:${$frontmatter.email}`">{{ $frontmatter.email }}</a>
+            </div>
+            <div v-if="$frontmatter.org">{{ $frontmatter.org }}</div>
+            <div v-if="$frontmatter.website">
+              <a :href="$frontmatter.website" target="_blank" rel="noreferrer">{{ $frontmatter.website }}</a>
+            </div>
+          </div>
+        </AutoFit>
+      </div>
+    </div>
+
+    <!-- Optional logo in the corner -->
+    <img v-if="$frontmatter.logo"
+         :src="$frontmatter.logo"
+         alt="logo"
+         class="absolute right-8 bottom-8 max-h-[10vh] max-w-[20vw]" />
+  </div>
+</template>
+
+<style scoped>
+/* Let AutoFit control sizes (theme sizes are neutralized) */
+.auto-title { font-size: 1em; }
+.auto-subtitle { font-size: 1em; }
+</style>
+

--- a/expert/addons/amit-fit/styles.css
+++ b/expert/addons/amit-fit/styles.css
@@ -1,24 +1,35 @@
-/* ===== Global knobs (one place to tune defaults) ===== */
+/* ===== Global knobs (tweak once for the whole deck) ===== */
 :root {
-  /* Optional suggestion: change this to adjust the default title area once for the whole deck */
-  --amit-title-height: 10vh;
+  --cover-title-height: 32vh;
+  --cover-subtitle-height: 14vh;
+  --cover-meta-height: 12vh;
 }
 
-/* Headings: “Keynote big” but still classy.
-   Note: the layout’s <h1> uses .auto-title { font-size: 1em } to neutralize these sizes
-   so AutoFit can govern the displayed size. */
-.slidev-layout h1{
+:root {
+  --amit-title-height: 10vh;   /* default title row height */
+  --amit-subtitle-height: 6vh; /* default subtitle row height (only if used) */
+  --amit-safe-x: 6vw;          /* left/right safe padding */
+  --amit-bullet-indent: 1.25rem;
+  --amit-max-content: 80ch;    /* guard line length on projectors */
+}
+
+/* Ensure the default layout container always fills the viewport */
+.slidev-layout.default { height: 100%; }
+
+/* Headings (theme-wide).
+   Note: the layout neutralizes the title's font-size to 1em so AutoFit controls it. */
+.slidev-layout h1 {
   font-size: clamp(2.8rem, 6.5vmin, 5.2rem);
   line-height: 1.08;
   font-weight: 800;
   letter-spacing: -0.02em;
 }
-.slidev-layout h2{
+.slidev-layout h2 {
   font-size: clamp(2.2rem, 5vmin, 3.6rem);
   line-height: 1.12;
   font-weight: 800;
 }
-.slidev-layout h3{
+.slidev-layout h3 {
   font-size: clamp(1.6rem, 3.6vmin, 2.4rem);
   line-height: 1.18;
   font-weight: 700;

--- a/expert/expert-slides/Python in Depth Course plan.md
+++ b/expert/expert-slides/Python in Depth Course plan.md
@@ -1,22 +1,25 @@
 ---
 # enable MDC Syntax: https://sli.dev/features/mdc
 mdc: true
-title: "Python in Depth - course plan"
-layout: cover
 class: text-center
 theme: apple-basic
 addons:
   - ./addons/amit-fit
 
+layout: cover-fit
+title: Python in Depth
+subtitle: Course Plan
+by: Amit Kotlovski
+email: amit@amitkot.com
 ---
-
-# Python in Depth
-## Course Plan
-
-<p/>
-
-<div class="text-xl font-semibold">Amit Kotlovski</div>
-<div class="text-base"><a href="mailto:amit@amitkot.com">amit@amitkot.com</a></div>
+<!-- # Optional extras: -->
+<!-- # org: "amitkot.com" -->
+<!-- # website: "https://amitkot.com" -->
+<!-- # logo: "/assets/logo.svg" -->
+<!-- # coverTitleHeight: 36vh -->
+<!-- # coverSubtitleHeight: 12vh -->
+<!-- # coverMetaHeight: 10vh -->
+<!-- # titleMax: 88 -->
 
 ---
 layout: bullets-fit
@@ -61,6 +64,8 @@ title: Day 4 — Metaprogramming & Practice
 <!-- # titleMin: 28 -->
 <!-- # titleMax: 60 -->
 <!-- # titlePad: 8 -->
+<!-- # subtitle: "Advanced techniques" -->
+<!-- # subtitleHeight: 6vh -->
 
 - Metaclasses
 - getattr / getattribute


### PR DESCRIPTION
# Description

- Improve cover slide layout in the Amit-Fit addon
  - Introduce new CSS variables to control the height of cover title, subtitle, and meta sections
  - Ensure default layout container fills the viewport
  - Enhance heading styles (h1, h2, h3) for better consistency and visual appeal
  - Refactor `bullets-fit` layout to use a more flexible Flex-based layout instead of Grid
  - Add support for an optional subtitle section with its own AutoFit sizing
  - Introduce safe area padding and max content width to ensure bullet points are readable on projectors
- Update the layout and structure of the "Python in Depth" course plan slides
  - Update title, subtitle, and author information
  - Add optional extras for the cover page layout
  - Remove unnecessary content from the front matter
  - Prepare the slides for more advanced topics like Metaclasses and getattr/getattribute